### PR TITLE
Use millisecond precision and UTC for timestamps

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -19,9 +19,12 @@ type Time struct {
 	T time.Time
 }
 
+// rfc3339Milli is like time.RFC3339Nano, but with millisecond precision.
+const rfc3339Milli = "2006-01-02T15:04:05.999Z07:00"
+
 // Value satisfies driver.Valuer interface.
 func (t *Time) Value() (driver.Value, error) {
-	return t.T.Format(time.RFC3339Nano), nil
+	return t.T.UTC().Format(rfc3339Milli), nil
 }
 
 // Scan satisfies sql.Scanner interface.
@@ -35,12 +38,12 @@ func (t *Time) Scan(src any) error {
 		return errors.Newf("error scanning time, got %+v", src)
 	}
 
-	parsedT, err := time.Parse(time.RFC3339Nano, s)
+	parsedT, err := time.Parse(rfc3339Milli, s)
 	if err != nil {
 		return err
 	}
 
-	t.T = parsedT
+	t.T = parsedT.UTC()
 
 	return nil
 }

--- a/sql/migrations/1667384958-articles.up.sql
+++ b/sql/migrations/1667384958-articles.up.sql
@@ -9,5 +9,5 @@ create table articles (
 create index articles_created_idx on articles (created);
 
 create trigger articles_updated_timestamp after update on articles begin
-  update articles set updated = (strftime('%Y-%m-%dT%H:%M:%fZ')) where id = old.id;
+  update articles set updated = strftime('%Y-%m-%dT%H:%M:%fZ') where id = old.id;
 end;

--- a/sql/migrations/1667384958-articles.up.sql
+++ b/sql/migrations/1667384958-articles.up.sql
@@ -2,12 +2,12 @@ create table articles (
   id integer primary key,
   title text not null,
   content text not null,
-  created text not null default (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
-  updated text not null default (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+  created text not null default (strftime('%Y-%m-%dT%H:%M:%fZ')),
+  updated text not null default (strftime('%Y-%m-%dT%H:%M:%fZ'))
 ) strict;
 
 create index articles_created_idx on articles (created);
 
 create trigger articles_updated_timestamp after update on articles begin
-  update articles set updated = (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) where id = old.id;
+  update articles set updated = (strftime('%Y-%m-%dT%H:%M:%fZ')) where id = old.id;
 end;


### PR DESCRIPTION
Because e.g. `2022-11-11T12:34:56.000Z` sorts _after_ `2022-11-11T12:34:56.000000001Z`, restrict the timestamps used with SQLite to millisecond precision. This is because the built-in `strftime` of SQLite only supports millisecond precision, otherwise we could have switched to nanosecond precision everywhere.

An alternative is to not use the `strftime` function to create timestamps, but then we lose the ability to set timestamps on e.g. update triggers.

Also, always use UTC when (de)serializing `model.Time`.

Fixes #12.