### PR TITLE
add sqlite tags to migrate up/down to handle 'no such module: fts5' error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,11 @@ lint:
 
 .PHONY: migrate-down
 migrate-down:
-	go run ./cmd/migrate down
+	go run -tags "sqlite_fts5 sqlite_foreign_keys" ./cmd/migrate down
 
 .PHONY: migrate-up
 migrate-up:
-	go run ./cmd/migrate up
+	go run -tags "sqlite_fts5 sqlite_foreign_keys" ./cmd/migrate up
 
 .PHONY: open
 open:


### PR DESCRIPTION
I'm running on an older Ubuntu and I initially thought this error was related to my version of SQLite.
